### PR TITLE
Add RISC-V platform support in discoapi

### DIFF
--- a/src/main/java/io/foojay/api/distribution/Temurin.java
+++ b/src/main/java/io/foojay/api/distribution/Temurin.java
@@ -63,6 +63,7 @@ import static eu.hansolo.jdktools.Architecture.ARM;
 import static eu.hansolo.jdktools.Architecture.MIPS;
 import static eu.hansolo.jdktools.Architecture.PPC64;
 import static eu.hansolo.jdktools.Architecture.PPC64LE;
+import static eu.hansolo.jdktools.Architecture.RISCV64;
 import static eu.hansolo.jdktools.Architecture.SPARCV9;
 import static eu.hansolo.jdktools.Architecture.X64;
 import static eu.hansolo.jdktools.Architecture.X86;
@@ -96,7 +97,7 @@ public class Temurin implements Distribution {
     private static final String        BITNESS_PARAM          = "";
 
     // Mappings for url parameters
-    private static final Map<Architecture, String>    ARCHITECTURE_MAP         = Map.of(AARCH64, "aarch64", ARM, "arm", MIPS, "mips", PPC64, "ppc64", PPC64LE, "ppc64le", SPARCV9, "sparcv9", X64, "x64", X86, "x32");
+    private static final Map<Architecture, String>    ARCHITECTURE_MAP         = Map.of(AARCH64, "aarch64", ARM, "arm", MIPS, "mips", PPC64, "ppc64", PPC64LE, "ppc64le", SPARCV9, "sparcv9", X64, "x64", X86, "x32", RISCV64, "riscv64");
     private static final Map<OperatingSystem, String> OPERATING_SYSTEM_MAP     = Map.of(LINUX, "linux", MACOS, "mac", WINDOWS, "windows", SOLARIS, "solaris", AIX, "aix");
     private static final Map<PackageType, String>     PACKAGE_TYPE_MAP         = Map.of(JDK, "jdk", JRE, "jre");
     private static final Map<ReleaseStatus, String>   RELEASE_STATUS_MAP       = Map.of(EA, "ea", GA, "ga");


### PR DESCRIPTION
Following issue https://github.com/sdkman/sdkman-cli/issues/1321, I propose to add the `RISCV64` architecture to discoapi.

* Add `riscv64` architecture to `ARCHITECTURE_MAP` in `src/main/java/io/foojay/api/distribution/Temurin.java`.
* Update `getUrlForAvailablePkgs` method to include `riscv64` in `src/main/java/io/foojay/api/distribution/Temurin.java`.

## Summary 

- **New Features**
	- Added support for the `RISCV64` architecture in the architecture mapping, enhancing the capability to handle a broader range of architectures for package requests.

## Walkthrough
The changes introduced in this pull request involve the addition of a new architecture, `RISCV64`, to the `ARCHITECTURE_MAP` within the `Temurin` class. This update includes mapping the `RISCV64` architecture to the string representation "riscv64", allowing the `Temurin` class to support RISC-V 64-bit architecture in URL parameters. No other modifications to logic or error handling were made, ensuring that the existing functionality of the class remains unchanged.

## Changes

| File Path                                      | Change Summary                                           |
|------------------------------------------------|---------------------------------------------------------|
| src/main/java/io/foojay/api/distribution/Temurin.java | Added `RISCV64` to `ARCHITECTURE_MAP`, mapping to "riscv64". |